### PR TITLE
[AWRS-2106] - Lookup URL from AWRS

### DIFF
--- a/app/uk/gov/hmrc/feedbacksurveyfrontend/controllers/FeedbackSurveyController.scala
+++ b/app/uk/gov/hmrc/feedbacksurveyfrontend/controllers/FeedbackSurveyController.scala
@@ -20,10 +20,9 @@ import models.feedbackSurveyModels._
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import play.api.mvc._
 
-import scala.concurrent.Future
 import play.api.Play.{current}
 import play.api.i18n.Messages.Implicits._
-import utils.{SessionUtil, LoggingUtils}
+import utils.LoggingUtils
 import utils.FeedbackSurveySessionKeys._
 
 

--- a/app/uk/gov/hmrc/feedbacksurveyfrontend/controllers/HomeController.scala
+++ b/app/uk/gov/hmrc/feedbacksurveyfrontend/controllers/HomeController.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-import models.feedbackSurveyModels.formMappings
 import play.api.Play.current
 import play.api.i18n.Messages
 import play.api.i18n.Messages.Implicits._
@@ -24,8 +23,6 @@ import play.api.mvc._
 import controllers.bindable.Origin
 import uk.gov.hmrc.play.frontend.controller.FrontendController
 import utils.FeedbackSurveySessionKeys._
-
-import scala.concurrent.Future
 
 object HomeController extends HomeController
 
@@ -35,8 +32,7 @@ trait HomeController extends FrontendController  {
     implicit request =>
     Origin(originService.value).isValid match {
       case true =>  {
-        Ok(uk.gov.hmrc.feedbacksurveyfrontend.views.html.feedbackSurvey.ableToDo(formMappings.ableToDoForm)).withSession(request.session + (sessionOriginService -> originService.value))
-        //Redirect(routes.FeedbackSurveyController.ableToDo).withSession(request.session + (sessionOriginService -> originService.value))
+        Redirect(routes.FeedbackSurveyController.ableToDo).withSession(request.session + (sessionOriginService -> originService.value))
       }
       case false => Ok(uk.gov.hmrc.feedbacksurveyfrontend.views.html.error_template(Messages("global_errors.title"), Messages("global_errors.heading"), Messages("global_errors.message")))
     }

--- a/test/uk/gov/hmrc/feedbacksurveyfrontend/controllers/HomeControllerTest.scala
+++ b/test/uk/gov/hmrc/feedbacksurveyfrontend/controllers/HomeControllerTest.scala
@@ -49,7 +49,7 @@ class HomeControllerTest extends UnitSpec with FakeApplication with MockitoSugar
     "give a status of OK, if origin token found" in {
       val controllerUnderTest = buildFakeHomeController
       val result = controllerUnderTest.start(Origin("check-the-awrs-register")).apply(FakeRequest("GET", ""))
-      status(result) shouldBe OK
+      status(result) shouldBe SEE_OTHER
     }
 
   }


### PR DESCRIPTION
[AWRS-2106] - Lookup URL from AWRS
Revert back to redirect on root call (now shows a more user friendly URL)
Upgrade to later version of frontend-bootstrap has resolved the issue with loss of session data + missing CSRF token